### PR TITLE
add single quotes around the name variable.

### DIFF
--- a/templates/exabgp.conf.j2
+++ b/templates/exabgp.conf.j2
@@ -1,6 +1,6 @@
 # ansible_managed
 {% for conf in exabgp_conf %}
-{{ conf.section }} {% if name in conf %}{{ conf.name }}{% endif %} {
+{{ conf.section }} {% if 'name' in conf %}{{ conf.name }}{% endif %} {
 {{ conf.config }}
 }
 {% endfor %}


### PR DESCRIPTION
The name variable needs to be quoted.
